### PR TITLE
Revert "Bump @angular/core from 9.1.4 to 11.0.5 in /imageserver/ui-frontend"

### DIFF
--- a/imageserver/ui-frontend/package-lock.json
+++ b/imageserver/ui-frontend/package-lock.json
@@ -471,19 +471,9 @@
       }
     },
     "@angular/core": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-11.0.5.tgz",
-      "integrity": "sha512-XAXWQi7R3ucZXQwx9QK5jSKJeQyRJ53u2dQDpr7R5stzeCy1a5hrNOkZLg9zOTTPcth/6+FrOrRZP9SMdxtw3w==",
-      "requires": {
-        "tslib": "^2.0.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
-        }
-      }
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-9.1.4.tgz",
+      "integrity": "sha512-ND240vncmVD2KVe/KSQU3d/DxxoRipFg1+jFOFZGt0n0orCBHk/V1fu9iaG1sRyldL0+rCQ+fTI+1N4DTmMnxA=="
     },
     "@angular/forms": {
       "version": "9.1.4",

--- a/imageserver/ui-frontend/package.json
+++ b/imageserver/ui-frontend/package.json
@@ -15,7 +15,7 @@
     "@angular/cdk": "^9.2.2",
     "@angular/common": "~9.1.4",
     "@angular/compiler": "~9.1.4",
-    "@angular/core": "~11.0.5",
+    "@angular/core": "~9.1.4",
     "@angular/forms": "~9.1.4",
     "@angular/material": "^9.2.2",
     "@angular/platform-browser": "~9.1.4",


### PR DESCRIPTION
This reverts commit 6ba1b26d61a7fc047e5b741de8c5edf61625c44b.

Container ui-frontend fails to build after this change so a manual update to a newer Angular version is required.